### PR TITLE
Add Workflow Jobs For Windows And Mac

### DIFF
--- a/.github/workflows/pull_request_flow.yaml
+++ b/.github/workflows/pull_request_flow.yaml
@@ -10,4 +10,20 @@ jobs:
         with:
           node-version: '14'
       - run: npm help
+  build-test-release-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+      - run: npm help
+  build-test-release-mac:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+      - run: npm help
 

--- a/.github/workflows/pull_request_flow.yaml
+++ b/.github/workflows/pull_request_flow.yaml
@@ -1,8 +1,6 @@
 name: Build, Test And Release
 run-name: ${{ github.actor }} triggered the workflow
-on:
-  pull_request:
-    [main]
+on: [pull_request]
 jobs:
   build-test-release-ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Now that the workflow is running for Ubuntu, I am adding jobs for Windows and Mac. They both use the latest OSes. 